### PR TITLE
Split output into multiple strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Suppose we have already captured 5 groups representing the strings `1`, `2`, `3`
 - `{-6}` results in nothing
 - `{-3..}` results in `3 4 5`
 
+## Split ranges
+
+Field ranges will still pass in one argument to the command. You can split these with the syntax `{...}`. Specifying endpoints to the range works the same as the non-split ranges.
+
 ### Multiple threading
 
 You can run commands in multiple threads to improve performance:

--- a/src/main.rs
+++ b/src/main.rs
@@ -460,7 +460,7 @@ impl<'a> ArgTemplate {
                     context.get_by_name(name).map_or_else(Vec::new, |c| vec![c])
                 }
                 RangeGroup(ref range, ref opt_sep) => {
-                    context.get_by_range(range, opt_sep.as_ref().map(|s| &**s))
+                    context.get_by_range(range, opt_sep.as_ref().map(String::as_str))
                 }
             })
             .filter_map(|c| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,8 @@ lazy_static! {
         Regex::new(r"^\{[[:space:]]*(?P<num>-?\d+)[[:space:]]*\}$").unwrap();
     static ref FIELD_RANGE: Regex =
         Regex::new(r"^\{(?P<left>-?\d*)?\.\.(?P<right>-?\d*)?(?::(?P<sep>.*))?\}$").unwrap();
+    static ref FIELD_SPLIT_RANGE: Regex =
+        Regex::new(r"^\{(?P<left>-?\d*)?\.\.\.(?P<right>-?\d*)?\}$").unwrap();
 }
 
 #[derive(StructOpt, Debug)]
@@ -227,7 +229,8 @@ impl Rargs {
 
 trait Context<'a> {
     fn get_by_name(&'a self, group_name: &str) -> Option<Cow<'a, str>>;
-    fn get_by_range(&'a self, range: &Range, sep: Option<&str>) -> Vec<Cow<'a, str>>;
+    fn get_by_range(&'a self, range: &Range, sep: Option<&str>) -> Option<Cow<'a, str>>;
+    fn get_by_split_range(&'a self, range: &Range) -> Vec<Cow<'a, str>>;
 }
 
 /// The context parsed from the input line using the pattern given. For Example:
@@ -308,7 +311,67 @@ impl<'a> Context<'a> for RegexContext<'a> {
         self.map.get(group_name).map(|c| c.clone())
     }
 
-    fn get_by_range(&'a self, range: &Range, sep: Option<&str>) -> Vec<Cow<'a, str>> {
+    fn get_by_range(&'a self, range: &Range, sep: Option<&str>) -> Option<Cow<'a, str>> {
+        match *range {
+            Single(num) => {
+                let num = self.translate_neg_index(num);
+
+                if num == 0 {
+                    return self.map.get("").map(|c| c.clone());
+                } else if num > self.groups.len() {
+                    return None;
+                }
+
+                let x = Some(self.groups[num - 1].clone());
+                return x;
+            }
+
+            Both(left, right) => {
+                let left = self.translate_neg_index(left);
+                let right = self.translate_neg_index(right);
+
+                if left == 0 {
+                    return self.get_by_range(&LeftInf(right as i32), sep);
+                } else if right > self.groups.len() {
+                    return self.get_by_range(&RightInf(left as i32), sep);
+                } else if left == right {
+                    return self.get_by_range(&Single(left as i32), sep);
+                }
+
+                Some(Cow::Owned(
+                    self.groups[(left - 1)..right].join(sep.unwrap_or(&self.default_sep)),
+                ))
+            }
+
+            LeftInf(right) => {
+                let right = self.translate_neg_index(right);
+                if right > self.groups.len() {
+                    return self.get_by_range(&Inf(), sep);
+                }
+
+                Some(Cow::Owned(
+                    self.groups[..right].join(sep.unwrap_or(&self.default_sep)),
+                ))
+            }
+
+            RightInf(left) => {
+                let left = self.translate_neg_index(left);
+                if left == 0 {
+                    return self.get_by_range(&Inf(), sep);
+                }
+
+                Some(Cow::Owned(
+                    self.groups[(left - 1)..].join(sep.unwrap_or(&self.default_sep)),
+                ))
+            }
+
+            Inf() => Some(Cow::Owned(
+                self.groups.join(sep.unwrap_or(&self.default_sep)),
+            )),
+        }
+    }
+
+    fn get_by_split_range(&'a self, range: &Range) -> Vec<Cow<'a, str>> {
         match *range {
             Single(num) => {
                 let num = self.translate_neg_index(num);
@@ -327,11 +390,11 @@ impl<'a> Context<'a> for RegexContext<'a> {
                 let right = self.translate_neg_index(right);
 
                 if left == 0 {
-                    return self.get_by_range(&LeftInf(right as i32), sep);
+                    return self.get_by_split_range(&LeftInf(right as i32));
                 } else if right > self.groups.len() {
-                    return self.get_by_range(&RightInf(left as i32), sep);
+                    return self.get_by_split_range(&RightInf(left as i32));
                 } else if left == right {
-                    return self.get_by_range(&Single(left as i32), sep);
+                    return self.get_by_split_range(&Single(left as i32));
                 }
 
                 self.groups[(left - 1)..right].to_vec()
@@ -340,7 +403,7 @@ impl<'a> Context<'a> for RegexContext<'a> {
             LeftInf(right) => {
                 let right = self.translate_neg_index(right);
                 if right > self.groups.len() {
-                    return self.get_by_range(&Inf(), sep);
+                    return self.get_by_split_range(&Inf());
                 }
 
                 self.groups[..right].to_vec()
@@ -349,7 +412,7 @@ impl<'a> Context<'a> for RegexContext<'a> {
             RightInf(left) => {
                 let left = self.translate_neg_index(left);
                 if left == 0 {
-                    return self.get_by_range(&Inf(), sep);
+                    return self.get_by_split_range(&Inf());
                 }
 
                 self.groups[(left - 1)..].to_vec()
@@ -376,6 +439,7 @@ enum ArgFragment {
     Literal(String),
     NamedGroup(String),
     RangeGroup(Range, Option<String>),
+    SplitRangeGroup(Range),
 }
 
 use ArgFragment::*;
@@ -423,6 +487,22 @@ impl ArgFragment {
             }
         }
 
+        let opt_caps = FIELD_SPLIT_RANGE.captures(field_string);
+        if let Some(caps) = opt_caps {
+            let opt_left = caps.name("left").map(|s| s.as_str().parse().unwrap_or(1));
+            let opt_right = caps.name("right").map(|s| s.as_str().parse().unwrap_or(-1));
+
+            if opt_left.is_none() && opt_right.is_none() {
+                return SplitRangeGroup(Inf());
+            } else if opt_left.is_none() {
+                return SplitRangeGroup(LeftInf(opt_right.unwrap()));
+            } else if opt_right.is_none() {
+                return SplitRangeGroup(RightInf(opt_left.unwrap()));
+            } else {
+                return SplitRangeGroup(Both(opt_left.unwrap(), opt_right.unwrap()));
+            }
+        }
+
         return Literal(field_string.to_string());
     }
 }
@@ -459,9 +539,10 @@ impl<'a> ArgTemplate {
                 NamedGroup(ref name) => {
                     context.get_by_name(name).map_or_else(Vec::new, |c| vec![c])
                 }
-                RangeGroup(ref range, ref opt_sep) => {
-                    context.get_by_range(range, opt_sep.as_ref().map(String::as_str))
-                }
+                RangeGroup(ref range, ref opt_sep) => context
+                    .get_by_range(range, opt_sep.as_ref().map(String::as_str))
+                    .map_or_else(Vec::new, |c| vec![c]),
+                SplitRangeGroup(ref range) => context.get_by_split_range(range),
             })
             .filter_map(|c| {
                 let s = c.into_owned();

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,7 @@ impl Rargs {
 
         self.args
             .iter()
-            .map(|arg| arg.apply_context(&context))
+            .flat_map(|arg| arg.apply_context(&context))
             .collect()
     }
 
@@ -227,7 +227,7 @@ impl Rargs {
 
 trait Context<'a> {
     fn get_by_name(&'a self, group_name: &str) -> Option<Cow<'a, str>>;
-    fn get_by_range(&'a self, range: &Range, sep: Option<&str>) -> Option<Cow<'a, str>>;
+    fn get_by_range(&'a self, range: &Range, sep: Option<&str>) -> Vec<Cow<'a, str>>;
 }
 
 /// The context parsed from the input line using the pattern given. For Example:
@@ -308,19 +308,18 @@ impl<'a> Context<'a> for RegexContext<'a> {
         self.map.get(group_name).map(|c| c.clone())
     }
 
-    fn get_by_range(&'a self, range: &Range, sep: Option<&str>) -> Option<Cow<'a, str>> {
+    fn get_by_range(&'a self, range: &Range, sep: Option<&str>) -> Vec<Cow<'a, str>> {
         match *range {
             Single(num) => {
                 let num = self.translate_neg_index(num);
 
                 if num == 0 {
-                    return self.map.get("").map(|c| c.clone());
+                    return self.map.get("").map_or_else(Vec::new, |c| vec![c.clone()]);
                 } else if num > self.groups.len() {
-                    return None;
+                    return vec![];
                 }
 
-                let x = Some(self.groups[num - 1].clone());
-                return x;
+                vec![self.groups[num - 1].clone()]
             }
 
             Both(left, right) => {
@@ -335,9 +334,7 @@ impl<'a> Context<'a> for RegexContext<'a> {
                     return self.get_by_range(&Single(left as i32), sep);
                 }
 
-                Some(Cow::Owned(
-                    self.groups[(left - 1)..right].join(sep.unwrap_or(&self.default_sep)),
-                ))
+                self.groups[(left - 1)..right].to_vec()
             }
 
             LeftInf(right) => {
@@ -346,9 +343,7 @@ impl<'a> Context<'a> for RegexContext<'a> {
                     return self.get_by_range(&Inf(), sep);
                 }
 
-                Some(Cow::Owned(
-                    self.groups[..right].join(sep.unwrap_or(&self.default_sep)),
-                ))
+                self.groups[..right].to_vec()
             }
 
             RightInf(left) => {
@@ -357,14 +352,10 @@ impl<'a> Context<'a> for RegexContext<'a> {
                     return self.get_by_range(&Inf(), sep);
                 }
 
-                Some(Cow::Owned(
-                    self.groups[(left - 1)..].join(sep.unwrap_or(&self.default_sep)),
-                ))
+                self.groups[(left - 1)..].to_vec()
             }
 
-            Inf() => Some(Cow::Owned(
-                self.groups.join(sep.unwrap_or(&self.default_sep)),
-            )),
+            Inf() => self.groups.to_vec(),
         }
     }
 }
@@ -460,17 +451,26 @@ impl<'a> From<&'a str> for ArgTemplate {
 }
 
 impl<'a> ArgTemplate {
-    fn apply_context<T: Context<'a>>(&self, context: &'a T) -> String {
+    fn apply_context<T: Context<'a>>(&self, context: &'a T) -> Vec<String> {
         self.fragments
             .iter()
-            .map(|fragment| match *fragment {
-                Literal(ref literal) => Cow::Borrowed(literal.as_str()),
-                NamedGroup(ref name) => context.get_by_name(name).unwrap_or(Cow::Borrowed("")),
-                RangeGroup(ref range, ref opt_sep) => context
-                    .get_by_range(range, opt_sep.as_ref().map(|s| &**s))
-                    .unwrap_or(Cow::Borrowed("")),
+            .flat_map(|fragment| match *fragment {
+                Literal(ref literal) => vec![Cow::Borrowed(literal.as_str())],
+                NamedGroup(ref name) => {
+                    context.get_by_name(name).map_or_else(Vec::new, |c| vec![c])
+                }
+                RangeGroup(ref range, ref opt_sep) => {
+                    context.get_by_range(range, opt_sep.as_ref().map(|s| &**s))
+                }
             })
-            .collect::<Vec<Cow<str>>>()
-            .concat()
+            .filter_map(|c| {
+                let s = c.into_owned();
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            })
+            .collect()
     }
 }


### PR DESCRIPTION
## Split ranges

Field ranges will still pass in one argument to the command. You can split these with the syntax `{...}`. Specifying endpoints to the range works the same as the non-split ranges.